### PR TITLE
rm bare-v8 workaround

### DIFF
--- a/bare-v8/index.js
+++ b/bare-v8/index.js
@@ -1,7 +1,0 @@
-module.exports = {
-  getHeapSpaceStatistics: () => {
-    const err = new Error('Not implemented')
-    err.code = 'ERR_NOT_IMPLEMENTED'
-    throw err
-  }
-}

--- a/bare-v8/package.json
+++ b/bare-v8/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "bare-v8",
-  "version": "1.0.0",
-  "main": "index.js"
-}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   },
   "files": [
     "index.js",
-    "imports.json",
-    "bare-v8/"
+    "imports.json"
   ],
   "repository": {
     "type": "git",
@@ -53,7 +52,6 @@
     "bare-prom-client": "^15.1.4",
     "bare-url": "^2.2.2",
     "bare-utils": "^1.5.1",
-    "bare-v8": "file://./bare-v8",
     "bare-zlib": "^1.3.1",
     "dht-prom-client": "^2.0.1",
     "hypercore-stats": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "bare-prom-client": "^15.1.4",
     "bare-url": "^2.2.2",
     "bare-utils": "^1.5.1",
+    "bare-v8": "^1.0.1",
     "bare-zlib": "^1.3.1",
     "dht-prom-client": "^2.0.1",
     "hypercore-stats": "^2.0.0",


### PR DESCRIPTION
Unneeded now we use bare-prom-client