### PR TITLE
Add hypercore-storage tree-cache stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,9 @@ class HyperInstrumentation extends ReadyResource {
     if (corestore) {
       this.hypercoreStats = HypercoreStats.fromCorestore(corestore)
       this.hypercoreStats.registerPrometheusMetrics(promClient)
+
+      // TODO: these corestore-level stats should be defined in hypecore-stats
+      registerExtraCorestoreStats(corestore)
     }
 
     this.dhtPromClient = new DhtPromClient(
@@ -144,6 +147,47 @@ function maybeRegisterPm2Name() {
     labelNames: ['pm2_name'],
     collect() {
       this.labels(process.env.name).set(1)
+    }
+  })
+}
+
+function registerExtraCorestoreStats(corestore) {
+  if (!corestore.storage.stats?.treeCache) return
+
+  new promClient.Gauge({
+    name: 'corestore_tree_cache_hits',
+    help: 'cache hits in the hypercore storage tree-node cache',
+    collect() {
+      this.set(corestore.storage.stats.treeCache.hits)
+    }
+  })
+  new promClient.Gauge({
+    name: 'corestore_tree_cache_misses',
+    help: 'cache misses in the hypercore storage tree-node cache',
+    collect() {
+      this.set(corestore.storage.stats.treeCache.misses)
+    }
+  })
+  new promClient.Gauge({
+    name: 'corestore_tree_cache_parallel',
+    help: 'parallel cache hits in the hypercore storage tree-node cache',
+    collect() {
+      this.set(corestore.storage.stats.treeCache.parallel)
+    }
+  })
+  new promClient.Gauge({
+    name: 'corestore_tree_cache_skips',
+    help: 'cache skips in the hypercore storage tree-node cache',
+    collect() {
+      this.set(corestore.storage.stats.treeCache.skips)
+    }
+  })
+
+  new promClient.Gauge({
+    name: 'corestore_tree_cache_max_size',
+    help: 'max size of the hypercore storage tree-node cache',
+    collect() {
+      this.set(corestore.storage.treeCache.maxSize)
     }
   })
 }

--- a/test.js
+++ b/test.js
@@ -39,6 +39,12 @@ test('basic happy path', async (t) => {
   t.ok(txt.includes('package_version{version="1.0.0"}', 'package version included'))
   t.absent(txt.includes('autobase_version'), 'autobase not included if not available')
 
+  t.ok(txt.includes('corestore_tree_cache_hits 0'), 'hypercore version metric')
+  t.ok(txt.includes('corestore_tree_cache_misses 0'), 'corestore_tree_cache_misses')
+  t.ok(txt.includes('corestore_tree_cache_parallel 0'), 'corestore_tree_cache_parallel')
+  t.ok(txt.includes('corestore_tree_cache_skips 0'), 'corestore_tree_cache_skips')
+  t.ok(txt.includes('corestore_tree_cache_max_size'), 'corestore_tree_cache_max_size')
+
   if (DEBUG) console.log(txt)
 
   await client.close()


### PR DESCRIPTION
Ideally these would live in hypercore-stats, but that module does not treat corestore as a first-class citizen yet so would have been complicated. It probably needs a minor redesign (~corestore-stats instead of hypercore-stats), but don't want to block this PR on that